### PR TITLE
Use streamable HTTP transport for MCP

### DIFF
--- a/src/policyengine_api/main.py
+++ b/src/policyengine_api/main.py
@@ -62,8 +62,9 @@ logfire.instrument_fastapi(app)
 app.include_router(api_router)
 
 # Mount MCP server - exposes all API endpoints as MCP tools at /mcp
+# Using mount_http() for streamable HTTP transport (required by Claude Code)
 mcp = FastApiMCP(app)
-mcp.mount()
+mcp.mount_http()
 
 
 @app.get("/health")


### PR DESCRIPTION
The MCP endpoint was using the deprecated SSE transport (`mcp.mount()`) which only accepts GET requests. Claude Code uses the newer streamable HTTP transport which requires POST support.

Switching to `mcp.mount_http()` enables POST-based MCP communication as required by Claude Code's HTTP transport.