### PR TITLE
Add query parameter filtering for parameter-values endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,4 @@ ignore = []
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]

--- a/src/policyengine_api/api/parameter_values.py
+++ b/src/policyengine_api/api/parameter_values.py
@@ -18,13 +18,30 @@ router = APIRouter(prefix="/parameter-values", tags=["parameter-values"])
 
 
 @router.get("/", response_model=List[ParameterValueRead])
-def list_parameter_values(session: Session = Depends(get_session)):
-    """List all parameter values.
+def list_parameter_values(
+    parameter_id: UUID | None = None,
+    policy_id: UUID | None = None,
+    skip: int = 0,
+    limit: int = 100,
+    session: Session = Depends(get_session),
+):
+    """List parameter values with optional filtering.
 
     Parameter values store the numeric/string values for policy parameters
     at specific time periods (start_date to end_date).
+
+    Use `parameter_id` to filter by a specific parameter.
+    Use `policy_id` to filter by a specific policy reform.
     """
-    parameter_values = session.exec(select(ParameterValue)).all()
+    query = select(ParameterValue)
+
+    if parameter_id:
+        query = query.where(ParameterValue.parameter_id == parameter_id)
+
+    if policy_id:
+        query = query.where(ParameterValue.policy_id == policy_id)
+
+    parameter_values = session.exec(query.offset(skip).limit(limit)).all()
     return parameter_values
 
 

--- a/test_fixtures/__init__.py
+++ b/test_fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures package."""

--- a/test_fixtures/fixtures_parameters.py
+++ b/test_fixtures/fixtures_parameters.py
@@ -1,0 +1,106 @@
+"""Fixtures and helpers for parameter-related tests."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from policyengine_api.models import (
+    Parameter,
+    ParameterValue,
+    Policy,
+    TaxBenefitModel,
+    TaxBenefitModelVersion,
+)
+
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def model_version(session):
+    """Create a TaxBenefitModel and TaxBenefitModelVersion for testing."""
+    model = TaxBenefitModel(name="test-model", description="Test model")
+    session.add(model)
+    session.commit()
+    session.refresh(model)
+
+    version = TaxBenefitModelVersion(
+        model_id=model.id,
+        version="1.0.0",
+        description="Test version",
+    )
+    session.add(version)
+    session.commit()
+    session.refresh(version)
+    return version
+
+
+# -----------------------------------------------------------------------------
+# Factory Functions
+# -----------------------------------------------------------------------------
+
+
+def create_parameter(session, model_version, name: str, label: str) -> Parameter:
+    """Create and persist a Parameter."""
+    param = Parameter(
+        name=name,
+        label=label,
+        tax_benefit_model_version_id=model_version.id,
+    )
+    session.add(param)
+    session.commit()
+    session.refresh(param)
+    return param
+
+
+def create_policy(session, name: str, description: str = "A test policy") -> Policy:
+    """Create and persist a Policy."""
+    policy = Policy(name=name, description=description)
+    session.add(policy)
+    session.commit()
+    session.refresh(policy)
+    return policy
+
+
+def create_parameter_value(
+    session,
+    parameter_id,
+    value: int | float | dict,
+    policy_id=None,
+    start_date: datetime | None = None,
+) -> ParameterValue:
+    """Create and persist a ParameterValue."""
+    pv = ParameterValue(
+        parameter_id=parameter_id,
+        value_json=value,
+        start_date=start_date or datetime.now(timezone.utc),
+        policy_id=policy_id,
+    )
+    session.add(pv)
+    session.commit()
+    session.refresh(pv)
+    return pv
+
+
+def create_parameter_values_batch(
+    session,
+    parameter_id,
+    count: int,
+    value_multiplier: int = 100,
+) -> list[ParameterValue]:
+    """Create multiple ParameterValues for a parameter."""
+    pvs = []
+    for i in range(count):
+        pv = ParameterValue(
+            parameter_id=parameter_id,
+            value_json=i * value_multiplier,
+            start_date=datetime.now(timezone.utc),
+        )
+        session.add(pv)
+        pvs.append(pv)
+    session.commit()
+    for pv in pvs:
+        session.refresh(pv)
+    return pvs

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,29 +1,194 @@
-"""Tests for parameter endpoints."""
+"""Tests for parameter and parameter-value endpoints."""
 
 from uuid import uuid4
 
 import pytest
 
+from test_fixtures.fixtures_parameters import (
+    create_parameter,
+    create_parameter_value,
+    create_parameter_values_batch,
+    create_policy,
+    model_version,  # noqa: F401 - pytest fixture
+)
 
-def test_list_parameters(client):
-    """List parameters returns a list."""
-    response = client.get("/parameters")
+
+# -----------------------------------------------------------------------------
+# Parameter Endpoint Tests
+# -----------------------------------------------------------------------------
+
+
+def test__given_parameters_endpoint_called__then_returns_list(client):
+    """GET /parameters returns a list."""
+    # Given
+    endpoint = "/parameters"
+
+    # When
+    response = client.get(endpoint)
+
+    # Then
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
 
-def test_get_parameter_not_found(client):
-    """Get non-existent parameter returns 404."""
+def test__given_nonexistent_parameter_id__then_returns_404(client):
+    """GET /parameters/{id} returns 404 for non-existent parameter."""
+    # Given
     fake_id = uuid4()
+
+    # When
     response = client.get(f"/parameters/{fake_id}")
+
+    # Then
     assert response.status_code == 404
 
 
-def test_list_parameter_values(client):
-    """List parameter values returns a list."""
-    response = client.get("/parameter-values")
+# -----------------------------------------------------------------------------
+# Parameter Value Endpoint Tests
+# -----------------------------------------------------------------------------
+
+
+def test__given_parameter_values_endpoint_called__then_returns_list(client):
+    """GET /parameter-values returns a list."""
+    # Given
+    endpoint = "/parameter-values"
+
+    # When
+    response = client.get(endpoint)
+
+    # Then
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+
+def test__given_nonexistent_parameter_value_id__then_returns_404(client):
+    """GET /parameter-values/{id} returns 404 for non-existent parameter value."""
+    # Given
+    fake_id = uuid4()
+
+    # When
+    response = client.get(f"/parameter-values/{fake_id}")
+
+    # Then
+    assert response.status_code == 404
+
+
+# -----------------------------------------------------------------------------
+# Parameter Value Filtering Tests
+# -----------------------------------------------------------------------------
+
+
+def test__given_parameter_id_filter__then_returns_only_matching_values(
+    client, session, model_version  # noqa: F811
+):
+    """GET /parameter-values?parameter_id=X returns only values for that parameter."""
+    # Given
+    param1 = create_parameter(session, model_version, "test.param1", "Test Param 1")
+    param2 = create_parameter(session, model_version, "test.param2", "Test Param 2")
+    create_parameter_value(session, param1.id, 100)
+    create_parameter_value(session, param2.id, 200)
+
+    # When
+    response = client.get(f"/parameter-values?parameter_id={param1.id}")
+
+    # Then
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["parameter_id"] == str(param1.id)
+
+
+def test__given_policy_id_filter__then_returns_only_matching_values(
+    client, session, model_version  # noqa: F811
+):
+    """GET /parameter-values?policy_id=X returns only values for that policy."""
+    # Given
+    param = create_parameter(session, model_version, "test.param", "Test Param")
+    policy = create_policy(session, "Test Policy")
+    create_parameter_value(session, param.id, 100, policy_id=None)  # baseline
+    create_parameter_value(session, param.id, 150, policy_id=policy.id)  # reform
+
+    # When
+    response = client.get(f"/parameter-values?policy_id={policy.id}")
+
+    # Then
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["policy_id"] == str(policy.id)
+    assert data[0]["value_json"] == 150
+
+
+def test__given_both_parameter_and_policy_filters__then_returns_matching_intersection(
+    client, session, model_version  # noqa: F811
+):
+    """GET /parameter-values?parameter_id=X&policy_id=Y returns intersection."""
+    # Given
+    param1 = create_parameter(
+        session, model_version, "test.both.param1", "Test Both Param 1"
+    )
+    param2 = create_parameter(
+        session, model_version, "test.both.param2", "Test Both Param 2"
+    )
+    policy = create_policy(session, "Test Both Policy")
+
+    create_parameter_value(session, param1.id, 100, policy_id=None)  # baseline
+    create_parameter_value(session, param1.id, 150, policy_id=policy.id)  # target
+    create_parameter_value(session, param2.id, 200, policy_id=policy.id)  # other
+
+    # When
+    response = client.get(
+        f"/parameter-values?parameter_id={param1.id}&policy_id={policy.id}"
+    )
+
+    # Then
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["parameter_id"] == str(param1.id)
+    assert data[0]["policy_id"] == str(policy.id)
+    assert data[0]["value_json"] == 150
+
+
+# -----------------------------------------------------------------------------
+# Parameter Value Pagination Tests
+# -----------------------------------------------------------------------------
+
+
+def test__given_limit_parameter__then_returns_limited_results(
+    client, session, model_version  # noqa: F811
+):
+    """GET /parameter-values?limit=N returns at most N results."""
+    # Given
+    param = create_parameter(
+        session, model_version, "test.pagination.param", "Test Pagination Param"
+    )
+    create_parameter_values_batch(session, param.id, count=5)
+
+    # When
+    response = client.get(f"/parameter-values?parameter_id={param.id}&limit=2")
+
+    # Then
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test__given_skip_parameter__then_skips_specified_results(
+    client, session, model_version  # noqa: F811
+):
+    """GET /parameter-values?skip=N skips first N results."""
+    # Given
+    param = create_parameter(
+        session, model_version, "test.skip.param", "Test Skip Param"
+    )
+    create_parameter_values_batch(session, param.id, count=5)
+
+    # When
+    response = client.get(f"/parameter-values?parameter_id={param.id}&skip=3&limit=10")
+
+    # Then
+    assert response.status_code == 200
+    assert len(response.json()) == 2  # 5 total - 3 skipped = 2 remaining
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #17

## Summary

- Add `parameter_id` and `policy_id` query parameters to `GET /parameter-values/` endpoint for filtering results
- Add `skip` and `limit` query parameters for pagination (consistent with `/parameters` endpoint)
- Create `test_fixtures/` directory for shared test fixtures and factory functions
- Refactor parameter tests to follow given-when-then format with descriptive naming

## Changes

### API Changes
- `GET /parameter-values/` now accepts:
  - `parameter_id` (UUID, optional) - filter by specific parameter
  - `policy_id` (UUID, optional) - filter by specific policy reform
  - `skip` (int, default 0) - pagination offset
  - `limit` (int, default 100) - pagination limit

### Test Infrastructure
- New `test_fixtures/` directory with reusable fixtures and factory functions
- Added `pythonpath` to pytest configuration for fixture imports
- Tests now follow `test__given_X__then_Y` naming convention

## Test plan
- [x] Run `uv run pytest tests/test_parameters.py -v` - all 9 tests pass
- [ ] Verify filtering works with real data via API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)