### PR TITLE
API hierarchy design with consistent naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,41 @@
 # PolicyEngine API v2
 
-FastAPI backend for tax-benefit policy microsimulations using PolicyEngine's UK and US models. Provides endpoints for running simulations, comparing policy reforms, and aggregating results.
+FastAPI backend for tax-benefit policy microsimulations using PolicyEngine's UK and US models.
+
+## API hierarchy
+
+```
+Level 2: Reports        AI-generated documents (future)
+Level 1: Analyses       Operations on simulations (economy_comparison_*)
+Level 0: Simulations    Single world-state calculations (simulate_household_*)
+```
+
+See [docs/DESIGN.md](docs/DESIGN.md) for the full design including future endpoints.
+
+## How it works
+
+1. Client submits request to FastAPI (Cloud Run)
+2. API creates job record in Supabase and triggers Modal.com function
+3. Modal runs calculation with pre-loaded PolicyEngine models (sub-1s cold start)
+4. Modal writes results directly to Supabase
+5. Client polls API until job status = "completed"
+
+## Modal functions
+
+| Function | Purpose |
+|----------|---------|
+| `simulate_household_uk` | Single UK household calculation |
+| `simulate_household_us` | Single US household calculation |
+| `economy_comparison_uk` | UK economy comparison (decile impacts, budget impact) |
+| `economy_comparison_us` | US economy comparison |
 
 ## Tech stack
 
 - **Framework:** FastAPI with async endpoints
-- **Database:** Supabase (Postgres) with SQLModel ORM
-- **Package manager:** UV (not pip)
-- **Formatting:** Ruff (not black)
+- **Database:** Supabase (Postgres) via SQLModel
+- **Compute:** Modal.com serverless functions
+- **Package manager:** UV
+- **Formatting:** Ruff
 - **Testing:** Pytest with pytest-asyncio
 - **Deployment:** Terraform on GCP Cloud Run
 
@@ -23,40 +51,26 @@ make lint             # ruff linting with auto-fix
 make modal-deploy     # deploy Modal.com serverless functions
 ```
 
-Local development uses docker compose with a local Supabase instance. Copy `.env.example` to `.env` for local config.
-
 ## Project structure
 
-- `src/policyengine_api/api/` - FastAPI routers (14 endpoint groups)
+- `src/policyengine_api/api/` - FastAPI routers
 - `src/policyengine_api/models/` - SQLModel database models
 - `src/policyengine_api/services/` - database and storage services
 - `src/policyengine_api/modal_app.py` - Modal.com serverless functions
-- `supabase/migrations/` - SQL migrations for RLS and Postgres features
+- `supabase/migrations/` - SQL migrations
 - `terraform/` - GCP Cloud Run infrastructure
-- `docs/` - Next.js documentation site
+- `docs/` - Next.js docs site + DESIGN.md
 
 ## Key patterns
 
-SQLModel defines all database schemas. Use Pydantic BaseModel for request/response schemas and BaseSettings for configuration. All API endpoints should be async functions.
-
-Modal.com serverless functions handle compute-intensive simulations with sub-1s cold starts. Clients poll simulation status until complete.
-
-MCP server exposes all endpoints as Claude tools via streamable HTTP transport.
-
-## Testing
-
-Run `make test` before committing. Unit tests use in-memory SQLite fixtures for speed. Integration tests require a running Supabase instance.
+SQLModel for database schemas, Pydantic BaseModel for request/response schemas. All calculation endpoints are async (submit job → poll for results). Modal functions use Supabase connection pooler for IPv4 compatibility. Analysis logic lives in `policyengine` package; API is thin orchestration layer.
 
 ## Deployment
 
-Never commit directly to main. Use PRs with passing tests. GitHub Actions runs tests on PRs, then deploys to Cloud Run on merge to main via Terraform.
+Never commit directly to main. PRs trigger tests; merging to main deploys to Cloud Run via Terraform.
 
-Use `gh` CLI for GitHub operations (not `git`) to ensure Actions run correctly.
+Use `gh` CLI for GitHub operations to ensure Actions run correctly.
 
 ## Database
 
-Use `make init` to reset and create tables/storage. Use `make seed` to populate UK/US models with variables, parameters, and datasets. Production reset requires explicit confirmation.
-
-## Observability
-
-Logfire provides automatic instrumentation. Add tracing to complex async flows.
+`make init` resets tables and storage. `make seed` populates UK/US models with variables, parameters, and datasets.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,331 @@
+# API hierarchy design
+
+## Levels of analysis
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Level 2: Reports                                           │
+│  AI-generated documents, orchestrating multiple jobs        │
+│  /reports/*                                                 │
+├─────────────────────────────────────────────────────────────┤
+│  Level 1: Analyses                                          │
+│  Operations on simulations - thin wrappers around           │
+│  policyengine package functions                             │
+│                                                             │
+│  Common (baked-in, trivial to call):                        │
+│    /analysis/decile-impact/*                                │
+│    /analysis/budget-impact/*                                │
+│    /analysis/winners-losers/*                               │
+│                                                             │
+│  Flexible (configurable):                                   │
+│    /analysis/compare/*                                      │
+├─────────────────────────────────────────────────────────────┤
+│  Level 0: Simulations                                       │
+│  Single world-state calculations                            │
+│  /simulate/household                                        │
+│  /simulate/economy                                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+All operations are **async** (Modal compute). The API is a thin orchestration layer - all analysis logic lives in the `policyengine` package.
+
+## Mapping to policyengine package
+
+| API endpoint | policyengine function |
+|--------------|----------------------|
+| `/simulate/household` | `calculate_household_impact()` |
+| `/simulate/economy` | `Simulation.run()` |
+| `/analysis/decile-impact/*` | `calculate_decile_impacts()` |
+| `/analysis/budget-impact/*` | `ProgrammeStatistics` |
+| `/analysis/winners-losers/*` | `ChangeAggregate` with filters |
+| `/analysis/compare/*` | `economic_impact_analysis()` or custom |
+
+## Level 0: Simulations
+
+### `/simulate/household`
+
+Single household calculation. Wraps `policyengine.tax_benefit_models.uk.analysis.calculate_household_impact()`.
+
+```
+POST /simulate/household
+{
+  "model": "policyengine_uk",
+  "household": {
+    "people": [{"age": 30, "employment_income": 50000}],
+    "benunit": {},
+    "household": {}
+  },
+  "year": 2026,
+  "policy_id": null
+}
+
+→ Returns job_id, poll for results
+```
+
+### `/simulate/economy`
+
+Population simulation. Creates and runs a `policyengine.core.Simulation`.
+
+```
+POST /simulate/economy
+{
+  "model": "policyengine_uk",
+  "dataset_id": "...",
+  "policy_id": null,
+  "dynamic_id": null
+}
+
+→ Returns simulation_id, poll for results
+```
+
+Economy simulations are **deterministic and cached** by (dataset_id, model_version, policy_id, dynamic_id).
+
+## Level 1: Analyses - Common (baked-in)
+
+These are the bread-and-butter analyses. Trivial to call, no configuration needed.
+
+### `/analysis/decile-impact/economy`
+
+Income decile breakdown. Wraps `calculate_decile_impacts()`.
+
+```
+POST /analysis/decile-impact/economy
+{
+  "model": "policyengine_uk",
+  "dataset_id": "...",
+  "baseline_policy_id": null,
+  "reform_policy_id": "..."
+}
+
+→ Returns job_id
+
+GET /analysis/decile-impact/economy/{job_id}
+→ Returns:
+{
+  "status": "completed",
+  "deciles": [
+    {"decile": 1, "baseline_mean": 15000, "reform_mean": 15500, "change": 500, "pct_change": 3.3, ...},
+    {"decile": 2, ...},
+    ...
+    {"decile": 10, ...}
+  ]
+}
+```
+
+### `/analysis/budget-impact/economy`
+
+Tax and benefit programme totals. Wraps `ProgrammeStatistics`.
+
+```
+POST /analysis/budget-impact/economy
+{
+  "model": "policyengine_uk",
+  "dataset_id": "...",
+  "baseline_policy_id": null,
+  "reform_policy_id": "..."
+}
+
+→ Returns job_id
+
+GET /analysis/budget-impact/economy/{job_id}
+→ Returns:
+{
+  "status": "completed",
+  "net_budget_impact": -20000000000,
+  "programmes": [
+    {"name": "income_tax", "is_tax": true, "baseline_total": 200e9, "reform_total": 180e9, "change": -20e9},
+    {"name": "universal_credit", "is_tax": false, "baseline_total": 50e9, "reform_total": 52e9, "change": 2e9},
+    ...
+  ]
+}
+```
+
+### `/analysis/winners-losers/economy`
+
+Who gains and loses. Wraps `ChangeAggregate` with change filters.
+
+```
+POST /analysis/winners-losers/economy
+{
+  "model": "policyengine_uk",
+  "dataset_id": "...",
+  "baseline_policy_id": null,
+  "reform_policy_id": "...",
+  "threshold": 0  // Change threshold (default: any change)
+}
+
+→ Returns job_id
+
+GET /analysis/winners-losers/economy/{job_id}
+→ Returns:
+{
+  "status": "completed",
+  "winners": {"count": 15000000, "mean_gain": 500},
+  "losers": {"count": 5000000, "mean_loss": -200},
+  "unchanged": {"count": 30000000}
+}
+```
+
+### `/analysis/decile-impact/household`
+
+Compare household across scenarios by artificial decile assignment.
+
+```
+POST /analysis/decile-impact/household
+{
+  "model": "policyengine_uk",
+  "household": {"people": [{"employment_income": 50000}]},
+  "year": 2026,
+  "baseline_policy_id": null,
+  "reform_policy_id": "..."
+}
+
+→ Returns which decile this household falls into and their change
+```
+
+## Level 1: Analyses - Flexible
+
+### `/analysis/compare/economy`
+
+Full comparison with all outputs. Wraps `economic_impact_analysis()`.
+
+```
+POST /analysis/compare/economy
+{
+  "model": "policyengine_uk",
+  "dataset_id": "...",
+  "scenarios": [
+    {"label": "baseline"},
+    {"label": "reform", "policy_id": "..."},
+    {"label": "reform_dynamic", "policy_id": "...", "dynamic_id": "..."}
+  ]
+}
+
+→ Returns job_id
+
+GET /analysis/compare/economy/{job_id}
+→ Returns:
+{
+  "status": "completed",
+  "scenarios": {...simulation results...},
+  "comparisons": {
+    "reform": {
+      "relative_to": "baseline",
+      "decile_impacts": [...],
+      "budget_impact": {...},
+      "winners_losers": {...}
+    },
+    "reform_dynamic": {...}
+  }
+}
+```
+
+### `/analysis/compare/household`
+
+Compare multiple scenarios for a household.
+
+```
+POST /analysis/compare/household
+{
+  "model": "policyengine_uk",
+  "household": {...},
+  "year": 2026,
+  "scenarios": [
+    {"label": "baseline"},
+    {"label": "reform", "policy_id": "..."}
+  ]
+}
+
+→ Returns all scenario results + computed differences
+```
+
+### `/analysis/aggregate/economy` (power user)
+
+Custom aggregation with full filter control. Directly exposes `Aggregate` / `ChangeAggregate`.
+
+```
+POST /analysis/aggregate/economy
+{
+  "model": "policyengine_uk",
+  "dataset_id": "...",
+  "simulation_id": "...",  // or policy_id to create
+  "variable": "household_net_income",
+  "aggregate_type": "mean",
+  "entity": "household",
+  "filters": {
+    "quantile": {"variable": "household_net_income", "n": 10, "eq": 1}
+  }
+}
+
+→ Returns single aggregate value
+```
+
+## Adding new analysis types
+
+To add a new common analysis (e.g. marginal tax rates):
+
+1. **policyengine package**: Add `MarginalTaxRate` output class and `calculate_marginal_rates()` function
+2. **API**: Add `/analysis/marginal-rates/*` endpoint that wraps the function
+3. **Modal**: Add function to run it
+
+The API endpoint is ~20 lines - just parameter parsing and calling the policyengine function.
+
+## URL structure summary
+
+```
+# Level 0: Simulations
+POST /simulate/household
+GET  /simulate/household/{job_id}
+POST /simulate/economy
+GET  /simulate/economy/{simulation_id}
+
+# Level 1: Common analyses (baked-in, trivial)
+POST /analysis/decile-impact/economy
+GET  /analysis/decile-impact/economy/{job_id}
+POST /analysis/budget-impact/economy
+GET  /analysis/budget-impact/economy/{job_id}
+POST /analysis/winners-losers/economy
+GET  /analysis/winners-losers/economy/{job_id}
+
+# Level 1: Flexible analyses
+POST /analysis/compare/economy
+GET  /analysis/compare/economy/{job_id}
+POST /analysis/compare/household
+GET  /analysis/compare/household/{job_id}
+POST /analysis/aggregate/economy
+GET  /analysis/aggregate/economy/{job_id}
+
+# Level 2: Reports (future)
+POST /reports/policy-impact
+GET  /reports/policy-impact/{report_id}
+```
+
+## Use cases
+
+| Use case | Endpoint |
+|----------|----------|
+| My tax under current law | `/simulate/household` |
+| Reform impact on my household | `/analysis/compare/household` with 2 scenarios |
+| Revenue impact of reform | `/analysis/budget-impact/economy` |
+| Decile breakdown of reform | `/analysis/decile-impact/economy` |
+| Who wins and loses | `/analysis/winners-losers/economy` |
+| Full reform analysis | `/analysis/compare/economy` |
+| Compare 3 reform proposals | `/analysis/compare/economy` with 4 scenarios |
+| Static vs dynamic comparison | `/analysis/compare/economy` with 3 scenarios |
+| Custom aggregation | `/analysis/aggregate/economy` |
+
+## Migration
+
+Deprecate existing endpoints:
+- `/household/calculate` → `/simulate/household`
+- `/household/impact` → `/analysis/compare/household`
+- `/analysis/economic-impact` → `/analysis/compare/economy`
+
+## Implementation notes
+
+1. All Modal functions import from `policyengine` package
+2. API endpoints do minimal work: parse request, call Modal, store results
+3. New analysis types require:
+   - Add to policyengine package (logic)
+   - Add API endpoint (orchestration)
+   - Add Modal function (compute)

--- a/src/policyengine_api/api/analysis.py
+++ b/src/policyengine_api/api/analysis.py
@@ -286,16 +286,16 @@ def _build_response(
     )
 
 
-def _trigger_modal_report(report_id: str, tax_benefit_model_name: str) -> None:
-    """Trigger Modal function for economic impact report."""
+def _trigger_economy_comparison(job_id: str, tax_benefit_model_name: str) -> None:
+    """Trigger Modal function for economy comparison analysis."""
     import modal
 
     if tax_benefit_model_name == "policyengine_uk":
-        fn = modal.Function.from_name("policyengine", "run_report_uk")
+        fn = modal.Function.from_name("policyengine", "economy_comparison_uk")
     else:
-        fn = modal.Function.from_name("policyengine", "run_report_us")
+        fn = modal.Function.from_name("policyengine", "economy_comparison_us")
 
-    fn.spawn(report_id=report_id)
+    fn.spawn(job_id=job_id)
 
 
 @router.post("/economic-impact", response_model=EconomicImpactResponse)
@@ -348,8 +348,8 @@ def economic_impact(
 
     # Trigger Modal if report is pending
     if report.status == ReportStatus.PENDING:
-        with logfire.span("trigger_modal_report", report_id=str(report.id)):
-            _trigger_modal_report(str(report.id), request.tax_benefit_model_name)
+        with logfire.span("trigger_economy_comparison", job_id=str(report.id)):
+            _trigger_economy_comparison(str(report.id), request.tax_benefit_model_name)
 
     return _build_response(report, baseline_sim, reform_sim, session)
 

--- a/src/policyengine_api/api/household.py
+++ b/src/policyengine_api/api/household.py
@@ -192,11 +192,11 @@ def _trigger_modal_household(
     policy_data: dict | None,
     dynamic_data: dict | None,
 ) -> None:
-    """Trigger Modal function for household calculation."""
+    """Trigger Modal function for household simulation."""
     import modal
 
     if request.tax_benefit_model_name == "policyengine_uk":
-        fn = modal.Function.from_name("policyengine", "calculate_household_uk")
+        fn = modal.Function.from_name("policyengine", "simulate_household_uk")
         fn.spawn(
             job_id=job_id,
             people=request.people,
@@ -207,7 +207,7 @@ def _trigger_modal_household(
             dynamic_data=dynamic_data,
         )
     else:
-        fn = modal.Function.from_name("policyengine", "calculate_household_us")
+        fn = modal.Function.from_name("policyengine", "simulate_household_us")
         fn.spawn(
             job_id=job_id,
             people=request.people,


### PR DESCRIPTION
Establishes a three-level API architecture documented in docs/DESIGN.md:

**Level 0: Simulations** - single-world snapshots (`/simulate/*`)
**Level 1: Analyses** - operations on simulations (`/analysis/*`)
**Level 2: Reports** - AI-generated documents (future)

Changes:
- Renames Modal functions for consistency: `simulate_household_*` and `economy_comparison_*`
- Updates all API endpoint references to use new names
- Adds full endpoint-to-policyengine-package mapping
- Documents use cases and URL structure

The API is a thin orchestration layer - all analysis logic lives in the policyengine package.