### PR TITLE
debug: log more chars, check for embedded newlines

### DIFF
--- a/src/policyengine_api/api/agent.py
+++ b/src/policyengine_api/api/agent.py
@@ -183,14 +183,17 @@ async def _stream_modal_sandbox(question: str, api_base_url: str):
                     logfire.info("reader_started")
                     for line in process.stdout:
                         lines_received += 1
-                        # Log line length and first 100 chars (avoid scrubbing)
+                        # Log line length and first 500 chars (avoid scrubbing)
                         line_preview = (
-                            line[:100].replace("session", "sess1on") if line else None
+                            line[:500].replace("session", "sess1on") if line else None
                         )
+                        # Check if multiple JSON objects concatenated (embedded newlines)
+                        newline_count = line.count("\n") if line else 0
                         logfire.info(
                             "raw_line",
                             line_num=lines_received,
                             line_len=len(line) if line else 0,
+                            newline_count=newline_count,
                             line_preview=line_preview,
                         )
                         line_queue.put(("line", line))

--- a/src/policyengine_api/main.py
+++ b/src/policyengine_api/main.py
@@ -18,11 +18,19 @@ console = Console()
 
 # Configure Logfire (only if token is set)
 if settings.logfire_token:
+
+    def _scrubbing_callback(m: logfire.ScrubMatch):
+        """Allow 'session' through for Claude stream debugging."""
+        if m.path in (("attributes", "line"), ("attributes", "line_preview")):
+            if m.pattern_match.group(0) == "session":
+                return m.value
+
     logfire.configure(
         service_name="policyengine-api",
         token=settings.logfire_token,
         environment=settings.logfire_environment,
         console=False,
+        scrubbing=logfire.ScrubbingOptions(callback=_scrubbing_callback),
     )
     logfire.instrument_httpx()
 


### PR DESCRIPTION
More debugging for the streaming issue:
- Log 500 chars instead of 100
- Count embedded newlines in line (to detect if Modal is concatenating)
- Add scrubbing callback for session