### PR TITLE
fix: pin Bun to 1.1.42 (segfault fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Build docs
-FROM oven/bun:1 AS docs-builder
+# Build docs (pin Bun version - 1.3.5 has segfault bugs with Next.js)
+FROM oven/bun:1.1.42 AS docs-builder
 WORKDIR /docs
 COPY docs/package.json docs/bun.lock ./
 RUN bun install


### PR DESCRIPTION
Bun 1.3.5 has a segfault bug during Next.js builds. Pin to 1.1.42 which is stable.