### PR TITLE
Phase 4: Custom computation modules

### DIFF
--- a/src/policyengine_api/api/analysis.py
+++ b/src/policyengine_api/api/analysis.py
@@ -25,6 +25,11 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
+from policyengine_api.api.module_registry import (
+    MODULE_REGISTRY,
+    get_modules_for_country,
+    validate_modules,
+)
 from policyengine_api.models import (
     BudgetSummary,
     BudgetSummaryRead,
@@ -32,8 +37,6 @@ from policyengine_api.models import (
     CongressionalDistrictImpactRead,
     ConstituencyImpact,
     ConstituencyImpactRead,
-    LocalAuthorityImpact,
-    LocalAuthorityImpactRead,
     Dataset,
     DecileImpact,
     DecileImpactRead,
@@ -41,6 +44,8 @@ from policyengine_api.models import (
     InequalityRead,
     IntraDecileImpact,
     IntraDecileImpactRead,
+    LocalAuthorityImpact,
+    LocalAuthorityImpactRead,
     Poverty,
     PovertyRead,
     ProgramStatistics,
@@ -53,11 +58,6 @@ from policyengine_api.models import (
     SimulationType,
     TaxBenefitModel,
     TaxBenefitModelVersion,
-)
-from policyengine_api.api.module_registry import (
-    MODULE_REGISTRY,
-    get_modules_for_country,
-    validate_modules,
 )
 from policyengine_api.services.database import get_session
 
@@ -477,9 +477,7 @@ def _build_response(
 
         # Fetch intra-decile impact records for this report
         intra_rows = session.exec(
-            select(IntraDecileImpact).where(
-                IntraDecileImpact.report_id == report.id
-            )
+            select(IntraDecileImpact).where(IntraDecileImpact.report_id == report.id)
         ).all()
         intra_decile_records = [
             IntraDecileImpactRead(
@@ -528,9 +526,7 @@ def _build_response(
 
         # Fetch constituency impact records for this report
         constituency_rows = session.exec(
-            select(ConstituencyImpact).where(
-                ConstituencyImpact.report_id == report.id
-            )
+            select(ConstituencyImpact).where(ConstituencyImpact.report_id == report.id)
         ).all()
         if constituency_rows:
             constituency_impact_records = [

--- a/src/policyengine_api/api/computation_modules.py
+++ b/src/policyengine_api/api/computation_modules.py
@@ -26,7 +26,6 @@ from policyengine_api.models import (
     ProgramStatistics,
 )
 
-
 # ---------------------------------------------------------------------------
 # Shared modules (UK + US)
 # ---------------------------------------------------------------------------
@@ -285,14 +284,10 @@ def compute_budget_summary_module_uk(
 
     # Household count: raw sum of weights (bypasses Aggregate weighting)
     baseline_hh_count = float(
-        pe_baseline_sim.output_dataset.data.household[
-            "household_weight"
-        ].values.sum()
+        pe_baseline_sim.output_dataset.data.household["household_weight"].values.sum()
     )
     reform_hh_count = float(
-        pe_reform_sim.output_dataset.data.household[
-            "household_weight"
-        ].values.sum()
+        pe_reform_sim.output_dataset.data.household["household_weight"].values.sum()
     )
     record = BudgetSummary(
         baseline_simulation_id=baseline_sim_id,
@@ -662,14 +657,10 @@ def compute_budget_summary_module_us(
 
     # Household count: raw sum of weights
     baseline_hh_count = float(
-        pe_baseline_sim.output_dataset.data.household[
-            "household_weight"
-        ].values.sum()
+        pe_baseline_sim.output_dataset.data.household["household_weight"].values.sum()
     )
     reform_hh_count = float(
-        pe_reform_sim.output_dataset.data.household[
-            "household_weight"
-        ].values.sum()
+        pe_reform_sim.output_dataset.data.household["household_weight"].values.sum()
     )
     record = BudgetSummary(
         baseline_simulation_id=baseline_sim_id,

--- a/src/policyengine_api/api/module_registry.py
+++ b/src/policyengine_api/api/module_registry.py
@@ -120,9 +120,7 @@ def validate_modules(names: list[str], country: str) -> list[str]:
         if name not in MODULE_REGISTRY:
             errors.append(f"Unknown module: {name!r}")
         elif name not in available:
-            errors.append(
-                f"Module {name!r} is not available for country {country!r}"
-            )
+            errors.append(f"Module {name!r} is not available for country {country!r}")
     if errors:
         raise ValueError("; ".join(errors))
     return names

--- a/tests/test_analysis_options.py
+++ b/tests/test_analysis_options.py
@@ -1,6 +1,6 @@
 """Tests for GET /analysis/options endpoint."""
 
-from policyengine_api.api.module_registry import MODULE_REGISTRY
+from policyengine_api.api.module_registry import MODULE_REGISTRY, get_modules_for_country
 
 
 class TestAnalysisOptions:
@@ -22,6 +22,31 @@ class TestAnalysisOptions:
             assert "response_fields" in item
             assert isinstance(item["response_fields"], list)
 
+    def test_all_names_are_strings(self, client):
+        response = client.get("/analysis/options")
+        for item in response.json():
+            assert isinstance(item["name"], str)
+            assert len(item["name"]) > 0
+
+    def test_all_labels_are_non_empty(self, client):
+        response = client.get("/analysis/options")
+        for item in response.json():
+            assert isinstance(item["label"], str)
+            assert len(item["label"]) > 0
+
+    def test_all_descriptions_are_non_empty(self, client):
+        response = client.get("/analysis/options")
+        for item in response.json():
+            assert isinstance(item["description"], str)
+            assert len(item["description"]) > 0
+
+    def test_all_response_fields_are_non_empty_lists(self, client):
+        response = client.get("/analysis/options")
+        for item in response.json():
+            assert len(item["response_fields"]) > 0
+            for field in item["response_fields"]:
+                assert isinstance(field, str)
+
     def test_filter_by_uk(self, client):
         response = client.get("/analysis/options?country=uk")
         assert response.status_code == 200
@@ -42,12 +67,31 @@ class TestAnalysisOptions:
         assert "local_authority" not in names
         assert "wealth_decile" not in names
 
+    def test_uk_count_matches_registry(self, client):
+        response = client.get("/analysis/options?country=uk")
+        data = response.json()
+        expected = len(get_modules_for_country("uk"))
+        assert len(data) == expected
+
+    def test_us_count_matches_registry(self, client):
+        response = client.get("/analysis/options?country=us")
+        data = response.json()
+        expected = len(get_modules_for_country("us"))
+        assert len(data) == expected
+
     def test_shared_modules_in_both_countries(self, client):
         uk_resp = client.get("/analysis/options?country=uk")
         us_resp = client.get("/analysis/options?country=us")
         uk_names = {m["name"] for m in uk_resp.json()}
         us_names = {m["name"] for m in us_resp.json()}
-        for shared in ["decile", "poverty", "inequality", "budget_summary", "intra_decile"]:
+        for shared in [
+            "decile",
+            "poverty",
+            "inequality",
+            "budget_summary",
+            "intra_decile",
+            "program_statistics",
+        ]:
             assert shared in uk_names
             assert shared in us_names
 
@@ -55,3 +99,31 @@ class TestAnalysisOptions:
         response = client.get("/analysis/options?country=fr")
         assert response.status_code == 200
         assert response.json() == []
+
+    def test_program_statistics_has_two_response_fields(self, client):
+        response = client.get("/analysis/options")
+        ps_module = next(
+            m for m in response.json() if m["name"] == "program_statistics"
+        )
+        assert "program_statistics" in ps_module["response_fields"]
+        assert "detailed_budget" in ps_module["response_fields"]
+
+    def test_wealth_decile_has_two_response_fields(self, client):
+        response = client.get("/analysis/options?country=uk")
+        wd_module = next(m for m in response.json() if m["name"] == "wealth_decile")
+        assert "wealth_decile" in wd_module["response_fields"]
+        assert "intra_wealth_decile" in wd_module["response_fields"]
+
+    def test_no_country_param_returns_all(self, client):
+        all_resp = client.get("/analysis/options")
+        data = all_resp.json()
+        returned_names = {m["name"] for m in data}
+        assert returned_names == set(MODULE_REGISTRY.keys())
+
+    def test_response_matches_registry_data(self, client):
+        response = client.get("/analysis/options")
+        for item in response.json():
+            registry_mod = MODULE_REGISTRY[item["name"]]
+            assert item["label"] == registry_mod.label
+            assert item["description"] == registry_mod.description
+            assert item["response_fields"] == list(registry_mod.response_fields)

--- a/tests/test_computation_modules.py
+++ b/tests/test_computation_modules.py
@@ -1,7 +1,10 @@
 """Tests for the composable computation module dispatch system."""
 
-from unittest.mock import MagicMock, patch
+import inspect
+from unittest.mock import MagicMock, call
+from uuid import uuid4
 
+from policyengine_api.api import computation_modules as cm
 from policyengine_api.api.computation_modules import (
     UK_MODULE_DISPATCH,
     US_MODULE_DISPATCH,
@@ -26,18 +29,14 @@ class TestDispatchTables:
     def test_uk_dispatch_covers_uk_modules(self):
         """UK dispatch should have an entry for every UK-applicable module."""
         uk_module_names = {
-            name
-            for name, mod in MODULE_REGISTRY.items()
-            if "uk" in mod.countries
+            name for name, mod in MODULE_REGISTRY.items() if "uk" in mod.countries
         }
         assert set(UK_MODULE_DISPATCH.keys()) == uk_module_names
 
     def test_us_dispatch_covers_us_modules(self):
         """US dispatch should have an entry for every US-applicable module."""
         us_module_names = {
-            name
-            for name, mod in MODULE_REGISTRY.items()
-            if "us" in mod.countries
+            name for name, mod in MODULE_REGISTRY.items() if "us" in mod.countries
         }
         assert set(US_MODULE_DISPATCH.keys()) == us_module_names
 
@@ -46,6 +45,133 @@ class TestDispatchTables:
             assert callable(fn)
         for fn in US_MODULE_DISPATCH.values():
             assert callable(fn)
+
+    def test_uk_dispatch_has_9_entries(self):
+        assert len(UK_MODULE_DISPATCH) == 9
+
+    def test_us_dispatch_has_7_entries(self):
+        assert len(US_MODULE_DISPATCH) == 7
+
+
+class TestSharedModuleFunctions:
+    """Tests that shared modules reference the same function objects."""
+
+    def test_decile_function_shared_between_uk_and_us(self):
+        assert UK_MODULE_DISPATCH["decile"] is US_MODULE_DISPATCH["decile"]
+        assert UK_MODULE_DISPATCH["decile"] is cm.compute_decile_module
+
+    def test_intra_decile_function_shared_between_uk_and_us(self):
+        assert UK_MODULE_DISPATCH["intra_decile"] is US_MODULE_DISPATCH["intra_decile"]
+        assert UK_MODULE_DISPATCH["intra_decile"] is cm.compute_intra_decile_module
+
+
+class TestCountrySpecificFunctions:
+    """Tests that UK/US specific modules use the correct country-specific functions."""
+
+    def test_uk_program_statistics(self):
+        assert (
+            UK_MODULE_DISPATCH["program_statistics"]
+            is cm.compute_program_statistics_module_uk
+        )
+
+    def test_us_program_statistics(self):
+        assert (
+            US_MODULE_DISPATCH["program_statistics"]
+            is cm.compute_program_statistics_module_us
+        )
+
+    def test_uk_poverty(self):
+        assert UK_MODULE_DISPATCH["poverty"] is cm.compute_poverty_module_uk
+
+    def test_us_poverty(self):
+        assert US_MODULE_DISPATCH["poverty"] is cm.compute_poverty_module_us
+
+    def test_uk_inequality(self):
+        assert UK_MODULE_DISPATCH["inequality"] is cm.compute_inequality_module_uk
+
+    def test_us_inequality(self):
+        assert US_MODULE_DISPATCH["inequality"] is cm.compute_inequality_module_us
+
+    def test_uk_budget_summary(self):
+        assert (
+            UK_MODULE_DISPATCH["budget_summary"]
+            is cm.compute_budget_summary_module_uk
+        )
+
+    def test_us_budget_summary(self):
+        assert (
+            US_MODULE_DISPATCH["budget_summary"]
+            is cm.compute_budget_summary_module_us
+        )
+
+    def test_constituency_is_uk_only(self):
+        assert UK_MODULE_DISPATCH["constituency"] is cm.compute_constituency_module
+        assert "constituency" not in US_MODULE_DISPATCH
+
+    def test_local_authority_is_uk_only(self):
+        assert (
+            UK_MODULE_DISPATCH["local_authority"] is cm.compute_local_authority_module
+        )
+        assert "local_authority" not in US_MODULE_DISPATCH
+
+    def test_wealth_decile_is_uk_only(self):
+        assert UK_MODULE_DISPATCH["wealth_decile"] is cm.compute_wealth_decile_module
+        assert "wealth_decile" not in US_MODULE_DISPATCH
+
+    def test_congressional_district_is_us_only(self):
+        assert (
+            US_MODULE_DISPATCH["congressional_district"]
+            is cm.compute_congressional_district_module
+        )
+        assert "congressional_district" not in UK_MODULE_DISPATCH
+
+
+class TestModuleFunctionSignatures:
+    """Tests that all module functions share the expected 6-param signature."""
+
+    _EXPECTED_PARAMS = [
+        "pe_baseline_sim",
+        "pe_reform_sim",
+        "baseline_sim_id",
+        "reform_sim_id",
+        "report_id",
+        "session",
+    ]
+
+    def _get_all_unique_functions(self):
+        """Collect all unique module functions from both dispatch tables."""
+        seen = set()
+        fns = []
+        for fn in list(UK_MODULE_DISPATCH.values()) + list(
+            US_MODULE_DISPATCH.values()
+        ):
+            if id(fn) not in seen:
+                seen.add(id(fn))
+                fns.append(fn)
+        return fns
+
+    def test_all_functions_have_6_parameters(self):
+        for fn in self._get_all_unique_functions():
+            sig = inspect.signature(fn)
+            assert len(sig.parameters) == 6, (
+                f"{fn.__name__} has {len(sig.parameters)} params, expected 6"
+            )
+
+    def test_all_functions_have_expected_param_names(self):
+        for fn in self._get_all_unique_functions():
+            sig = inspect.signature(fn)
+            param_names = list(sig.parameters.keys())
+            assert param_names == self._EXPECTED_PARAMS, (
+                f"{fn.__name__} params {param_names} != {self._EXPECTED_PARAMS}"
+            )
+
+    def test_all_functions_return_none(self):
+        for fn in self._get_all_unique_functions():
+            sig = inspect.signature(fn)
+            # `from __future__ import annotations` makes annotations strings
+            assert sig.return_annotation in (None, "None", inspect.Parameter.empty), (
+                f"{fn.__name__} return annotation is {sig.return_annotation!r}, expected None"
+            )
 
 
 class TestRunModules:
@@ -58,8 +184,6 @@ class TestRunModules:
     def test_runs_all_when_modules_is_none(self):
         dispatch = self._make_mock_dispatch(["a", "b", "c"])
         session = MagicMock()
-        from uuid import uuid4
-
         ids = [uuid4() for _ in range(3)]
 
         run_modules(dispatch, None, "bl", "rf", ids[0], ids[1], ids[2], session)
@@ -70,8 +194,6 @@ class TestRunModules:
     def test_runs_only_requested_modules(self):
         dispatch = self._make_mock_dispatch(["a", "b", "c"])
         session = MagicMock()
-        from uuid import uuid4
-
         ids = [uuid4() for _ in range(3)]
 
         run_modules(dispatch, ["b"], "bl", "rf", ids[0], ids[1], ids[2], session)
@@ -83,8 +205,6 @@ class TestRunModules:
     def test_ignores_unknown_module_names(self):
         dispatch = self._make_mock_dispatch(["a"])
         session = MagicMock()
-        from uuid import uuid4
-
         ids = [uuid4() for _ in range(3)]
 
         # Should not raise
@@ -97,11 +217,66 @@ class TestRunModules:
     def test_empty_modules_list_runs_nothing(self):
         dispatch = self._make_mock_dispatch(["a", "b"])
         session = MagicMock()
-        from uuid import uuid4
-
         ids = [uuid4() for _ in range(3)]
 
         run_modules(dispatch, [], "bl", "rf", ids[0], ids[1], ids[2], session)
 
         for fn in dispatch.values():
             fn.assert_not_called()
+
+    def test_preserves_call_order(self):
+        """Modules should be called in the order they appear in the modules list."""
+        call_order = []
+
+        def make_tracker(name):
+            def fn(*args):
+                call_order.append(name)
+
+            return fn
+
+        dispatch = {name: make_tracker(name) for name in ["a", "b", "c"]}
+        ids = [uuid4() for _ in range(3)]
+
+        run_modules(
+            dispatch, ["c", "a", "b"], "bl", "rf", ids[0], ids[1], ids[2], MagicMock()
+        )
+
+        assert call_order == ["c", "a", "b"]
+
+    def test_none_modules_runs_all_in_dispatch_key_order(self):
+        """When modules is None, all dispatch entries run in dict-iteration order."""
+        call_order = []
+
+        def make_tracker(name):
+            def fn(*args):
+                call_order.append(name)
+
+            return fn
+
+        dispatch = {name: make_tracker(name) for name in ["x", "y", "z"]}
+        ids = [uuid4() for _ in range(3)]
+
+        run_modules(dispatch, None, "bl", "rf", ids[0], ids[1], ids[2], MagicMock())
+
+        assert call_order == ["x", "y", "z"]
+
+    def test_passes_all_args_correctly(self):
+        mock_fn = MagicMock()
+        dispatch = {"test_mod": mock_fn}
+        session = MagicMock()
+        bl, rf, b_id, r_id, rep_id = "baseline", "reform", uuid4(), uuid4(), uuid4()
+
+        run_modules(dispatch, ["test_mod"], bl, rf, b_id, r_id, rep_id, session)
+
+        mock_fn.assert_called_once_with(bl, rf, b_id, r_id, rep_id, session)
+
+    def test_duplicate_module_name_runs_twice(self):
+        dispatch = self._make_mock_dispatch(["a"])
+        session = MagicMock()
+        ids = [uuid4() for _ in range(3)]
+
+        run_modules(
+            dispatch, ["a", "a"], "bl", "rf", ids[0], ids[1], ids[2], session
+        )
+
+        assert dispatch["a"].call_count == 2

--- a/tests/test_economy_custom.py
+++ b/tests/test_economy_custom.py
@@ -1,7 +1,6 @@
 """Tests for POST /analysis/economy-custom endpoint."""
 
-import pytest
-from unittest.mock import patch
+from uuid import uuid4
 
 from policyengine_api.api.analysis import (
     EconomicImpactResponse,
@@ -10,25 +9,20 @@ from policyengine_api.api.analysis import (
 )
 from policyengine_api.models import ReportStatus, SimulationStatus
 
-
 # ---------------------------------------------------------------------------
-# Unit tests for _build_filtered_response
+# Helpers
 # ---------------------------------------------------------------------------
 
 
 def _make_stub_response(**overrides) -> EconomicImpactResponse:
     """Build a minimal EconomicImpactResponse for testing."""
-    from uuid import uuid4
-
     defaults = dict(
         report_id=uuid4(),
         status=ReportStatus.COMPLETED,
         baseline_simulation=SimulationInfo(
             id=uuid4(), status=SimulationStatus.COMPLETED
         ),
-        reform_simulation=SimulationInfo(
-            id=uuid4(), status=SimulationStatus.COMPLETED
-        ),
+        reform_simulation=SimulationInfo(id=uuid4(), status=SimulationStatus.COMPLETED),
         region=None,
         error_message=None,
         decile_impacts=[{"fake": "decile"}],
@@ -46,6 +40,37 @@ def _make_stub_response(**overrides) -> EconomicImpactResponse:
     )
     defaults.update(overrides)
     return EconomicImpactResponse.model_construct(**defaults)
+
+
+# All data fields that can be nullified by module filtering
+_DATA_FIELDS = {
+    "decile_impacts",
+    "program_statistics",
+    "poverty",
+    "inequality",
+    "budget_summary",
+    "intra_decile",
+    "detailed_budget",
+    "congressional_district_impact",
+    "constituency_impact",
+    "local_authority_impact",
+    "wealth_decile",
+    "intra_wealth_decile",
+}
+
+_ALWAYS_INCLUDED = {
+    "report_id",
+    "status",
+    "baseline_simulation",
+    "reform_simulation",
+    "region",
+    "error_message",
+}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _build_filtered_response
+# ---------------------------------------------------------------------------
 
 
 class TestBuildFilteredResponse:
@@ -82,13 +107,105 @@ class TestBuildFilteredResponse:
         assert filtered.baseline_simulation is not None
         assert filtered.reform_simulation is not None
 
+    def test_region_always_included(self):
+        from policyengine_api.api.analysis import RegionInfo
+
+        region = RegionInfo(
+            code="uk",
+            label="United Kingdom",
+            region_type="national",
+            requires_filter=False,
+        )
+        resp = _make_stub_response(region=region)
+        filtered = _build_filtered_response(resp, ["decile"])
+        assert filtered.region is not None
+        assert filtered.region.code == "uk"
+
+    def test_error_message_always_included(self):
+        resp = _make_stub_response(error_message="something went wrong")
+        filtered = _build_filtered_response(resp, ["decile"])
+        assert filtered.error_message == "something went wrong"
+
     def test_empty_modules_nullifies_all_data_fields(self):
         resp = _make_stub_response()
         filtered = _build_filtered_response(resp, [])
-        assert filtered.decile_impacts is None
-        assert filtered.poverty is None
-        assert filtered.inequality is None
+        for field in _DATA_FIELDS:
+            assert getattr(filtered, field) is None, f"{field} should be None"
         assert filtered.report_id == resp.report_id
+
+    def test_empty_modules_preserves_always_included(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, [])
+        for field in _ALWAYS_INCLUDED:
+            original = getattr(resp, field)
+            assert getattr(filtered, field) == original, (
+                f"{field} should be preserved"
+            )
+
+    def test_wealth_decile_keeps_both_fields(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, ["wealth_decile"])
+        assert filtered.wealth_decile is not None
+        assert filtered.intra_wealth_decile is not None
+        assert filtered.decile_impacts is None
+        assert filtered.intra_decile is None
+
+    def test_intra_decile_keeps_only_intra_decile(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, ["intra_decile"])
+        assert filtered.intra_decile is not None
+        assert filtered.decile_impacts is None
+        assert filtered.intra_wealth_decile is None
+
+    def test_congressional_district_keeps_only_district_impact(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, ["congressional_district"])
+        assert filtered.congressional_district_impact is not None
+        assert filtered.constituency_impact is None
+        assert filtered.local_authority_impact is None
+
+    def test_constituency_keeps_only_constituency_impact(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, ["constituency"])
+        assert filtered.constituency_impact is not None
+        assert filtered.congressional_district_impact is None
+        assert filtered.local_authority_impact is None
+
+    def test_local_authority_keeps_only_la_impact(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, ["local_authority"])
+        assert filtered.local_authority_impact is not None
+        assert filtered.constituency_impact is None
+        assert filtered.congressional_district_impact is None
+
+    def test_budget_summary_keeps_only_budget(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, ["budget_summary"])
+        assert filtered.budget_summary is not None
+        assert filtered.decile_impacts is None
+        assert filtered.program_statistics is None
+
+    def test_unknown_module_in_list_is_gracefully_ignored(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, ["poverty", "nonexistent_module"])
+        assert filtered.poverty is not None
+        assert filtered.decile_impacts is None
+
+    def test_all_modules_keeps_all_data_fields(self):
+        from policyengine_api.api.module_registry import MODULE_REGISTRY
+
+        resp = _make_stub_response()
+        all_names = list(MODULE_REGISTRY.keys())
+        filtered = _build_filtered_response(resp, all_names)
+        for field in _DATA_FIELDS:
+            assert getattr(filtered, field) is not None, (
+                f"{field} should be preserved when all modules selected"
+            )
+
+    def test_returns_economic_impact_response_instance(self):
+        resp = _make_stub_response()
+        filtered = _build_filtered_response(resp, ["decile"])
+        assert isinstance(filtered, EconomicImpactResponse)
 
 
 # ---------------------------------------------------------------------------
@@ -123,9 +240,21 @@ class TestEconomyCustomEndpoint:
         assert response.status_code == 422
         assert "not available for country" in response.json()["detail"]
 
-    def test_empty_modules_list_returns_422(self, client):
-        """An empty modules list should still be accepted (no validation error)."""
-        # This will fail on dataset resolution (404), not module validation
+    def test_multiple_errors_in_module_validation(self, client):
+        response = client.post(
+            "/analysis/economy-custom",
+            json={
+                "tax_benefit_model_name": "policyengine_us",
+                "region": "us",
+                "modules": ["nonexistent", "constituency"],
+            },
+        )
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert "Unknown module" in detail
+        assert "not available for country" in detail
+
+    def test_empty_modules_list_passes_validation(self, client):
         response = client.post(
             "/analysis/economy-custom",
             json={
@@ -134,19 +263,55 @@ class TestEconomyCustomEndpoint:
                 "modules": [],
             },
         )
-        # Empty list passes validation, so the error should be about
+        # Empty list passes module validation, so the error should be about
         # dataset/region resolution, not about modules
-        assert response.status_code != 422 or "module" not in response.json().get(
-            "detail", ""
-        ).lower()
+        assert (
+            response.status_code != 422
+            or "module" not in response.json().get("detail", "").lower()
+        )
+
+    def test_valid_modules_but_missing_region_returns_404(self, client):
+        response = client.post(
+            "/analysis/economy-custom",
+            json={
+                "tax_benefit_model_name": "policyengine_us",
+                "region": "us",
+                "modules": ["decile", "poverty"],
+            },
+        )
+        # Passes validation but region "us" is not in the DB -> 404
+        assert response.status_code == 404
+
+    def test_missing_modules_field_returns_422(self, client):
+        response = client.post(
+            "/analysis/economy-custom",
+            json={
+                "tax_benefit_model_name": "policyengine_us",
+                "region": "us",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_invalid_model_name_returns_422(self, client):
+        response = client.post(
+            "/analysis/economy-custom",
+            json={
+                "tax_benefit_model_name": "invalid_model",
+                "region": "us",
+                "modules": ["decile"],
+            },
+        )
+        assert response.status_code == 422
 
 
 class TestEconomyCustomPolling:
     """Tests for GET /analysis/economy-custom/{report_id}."""
 
     def test_not_found(self, client):
-        from uuid import uuid4
-
         fake_id = uuid4()
         response = client.get(f"/analysis/economy-custom/{fake_id}")
         assert response.status_code == 404
+
+    def test_invalid_uuid_returns_422(self, client):
+        response = client.get("/analysis/economy-custom/not-a-uuid")
+        assert response.status_code == 422

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -1,7 +1,10 @@
 """Tests for the economy analysis module registry."""
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 
+from policyengine_api.api.analysis import EconomicImpactResponse
 from policyengine_api.api.module_registry import (
     MODULE_REGISTRY,
     ComputationModule,
@@ -17,6 +20,9 @@ class TestModuleRegistry:
     def test_registry_is_not_empty(self):
         assert len(MODULE_REGISTRY) > 0
 
+    def test_registry_has_exactly_10_modules(self):
+        assert len(MODULE_REGISTRY) == 10
+
     def test_all_entries_are_computation_modules(self):
         for name, module in MODULE_REGISTRY.items():
             assert isinstance(module, ComputationModule)
@@ -31,6 +37,16 @@ class TestModuleRegistry:
     def test_all_modules_have_response_fields(self):
         for module in MODULE_REGISTRY.values():
             assert len(module.response_fields) > 0
+
+    def test_all_modules_have_non_empty_label(self):
+        for name, module in MODULE_REGISTRY.items():
+            assert module.label, f"Module {name!r} has empty label"
+            assert len(module.label) > 0
+
+    def test_all_modules_have_non_empty_description(self):
+        for name, module in MODULE_REGISTRY.items():
+            assert module.description, f"Module {name!r} has empty description"
+            assert len(module.description) > 0
 
     def test_expected_modules_exist(self):
         expected = [
@@ -48,6 +64,93 @@ class TestModuleRegistry:
         for name in expected:
             assert name in MODULE_REGISTRY, f"Missing module: {name}"
 
+    def test_no_unexpected_modules(self):
+        expected = {
+            "decile",
+            "program_statistics",
+            "poverty",
+            "inequality",
+            "budget_summary",
+            "intra_decile",
+            "congressional_district",
+            "constituency",
+            "local_authority",
+            "wealth_decile",
+        }
+        assert set(MODULE_REGISTRY.keys()) == expected
+
+
+class TestComputationModuleFrozen:
+    """Tests that ComputationModule instances are immutable."""
+
+    def test_cannot_mutate_name(self):
+        module = MODULE_REGISTRY["decile"]
+        with pytest.raises(FrozenInstanceError):
+            module.name = "changed"
+
+    def test_cannot_mutate_countries(self):
+        module = MODULE_REGISTRY["decile"]
+        with pytest.raises(FrozenInstanceError):
+            module.countries = ["fr"]
+
+    def test_cannot_mutate_response_fields(self):
+        module = MODULE_REGISTRY["poverty"]
+        with pytest.raises(FrozenInstanceError):
+            module.response_fields = ["something_else"]
+
+
+class TestResponseFieldsMapping:
+    """Tests that each module's response_fields reference valid EconomicImpactResponse fields."""
+
+    def test_all_response_fields_exist_on_response_model(self):
+        valid_fields = set(EconomicImpactResponse.model_fields.keys())
+        for name, module in MODULE_REGISTRY.items():
+            for field in module.response_fields:
+                assert field in valid_fields, (
+                    f"Module {name!r} references response field {field!r} "
+                    f"which does not exist on EconomicImpactResponse"
+                )
+
+    def test_decile_response_fields(self):
+        assert MODULE_REGISTRY["decile"].response_fields == ["decile_impacts"]
+
+    def test_program_statistics_includes_detailed_budget(self):
+        fields = MODULE_REGISTRY["program_statistics"].response_fields
+        assert "program_statistics" in fields
+        assert "detailed_budget" in fields
+
+    def test_poverty_response_fields(self):
+        assert MODULE_REGISTRY["poverty"].response_fields == ["poverty"]
+
+    def test_inequality_response_fields(self):
+        assert MODULE_REGISTRY["inequality"].response_fields == ["inequality"]
+
+    def test_budget_summary_response_fields(self):
+        assert MODULE_REGISTRY["budget_summary"].response_fields == ["budget_summary"]
+
+    def test_intra_decile_response_fields(self):
+        assert MODULE_REGISTRY["intra_decile"].response_fields == ["intra_decile"]
+
+    def test_congressional_district_response_fields(self):
+        assert MODULE_REGISTRY["congressional_district"].response_fields == [
+            "congressional_district_impact"
+        ]
+
+    def test_constituency_response_fields(self):
+        assert MODULE_REGISTRY["constituency"].response_fields == [
+            "constituency_impact"
+        ]
+
+    def test_local_authority_response_fields(self):
+        assert MODULE_REGISTRY["local_authority"].response_fields == [
+            "local_authority_impact"
+        ]
+
+    def test_wealth_decile_includes_both_fields(self):
+        fields = MODULE_REGISTRY["wealth_decile"].response_fields
+        assert "wealth_decile" in fields
+        assert "intra_wealth_decile" in fields
+
 
 class TestCountryApplicability:
     """Tests for country-specific module availability."""
@@ -63,8 +166,14 @@ class TestCountryApplicability:
             assert "us" not in module.countries
 
     def test_shared_modules(self):
-        shared = ["decile", "program_statistics", "poverty", "inequality",
-                   "budget_summary", "intra_decile"]
+        shared = [
+            "decile",
+            "program_statistics",
+            "poverty",
+            "inequality",
+            "budget_summary",
+            "intra_decile",
+        ]
         for name in shared:
             module = MODULE_REGISTRY[name]
             assert "uk" in module.countries
@@ -86,6 +195,10 @@ class TestGetModulesForCountry:
         names = [m.name for m in uk_modules]
         assert "congressional_district" not in names
 
+    def test_uk_has_9_modules(self):
+        uk_modules = get_modules_for_country("uk")
+        assert len(uk_modules) == 9
+
     def test_us_includes_congressional_district(self):
         us_modules = get_modules_for_country("us")
         names = [m.name for m in us_modules]
@@ -98,8 +211,16 @@ class TestGetModulesForCountry:
         assert "local_authority" not in names
         assert "wealth_decile" not in names
 
+    def test_us_has_7_modules(self):
+        us_modules = get_modules_for_country("us")
+        assert len(us_modules) == 7
+
     def test_unknown_country_returns_empty(self):
         assert get_modules_for_country("fr") == []
+
+    def test_returns_computation_module_instances(self):
+        for m in get_modules_for_country("uk"):
+            assert isinstance(m, ComputationModule)
 
 
 class TestGetAllModuleNames:
@@ -108,6 +229,12 @@ class TestGetAllModuleNames:
     def test_returns_all_names(self):
         names = get_all_module_names()
         assert set(names) == set(MODULE_REGISTRY.keys())
+
+    def test_returns_list_of_strings(self):
+        names = get_all_module_names()
+        assert isinstance(names, list)
+        for name in names:
+            assert isinstance(name, str)
 
 
 class TestValidateModules:
@@ -121,6 +248,20 @@ class TestValidateModules:
         result = validate_modules(["constituency", "wealth_decile"], "uk")
         assert result == ["constituency", "wealth_decile"]
 
+    def test_empty_list_passes_validation(self):
+        result = validate_modules([], "us")
+        assert result == []
+
+    def test_all_us_modules_pass_validation(self):
+        us_names = [m.name for m in get_modules_for_country("us")]
+        result = validate_modules(us_names, "us")
+        assert result == us_names
+
+    def test_all_uk_modules_pass_validation(self):
+        uk_names = [m.name for m in get_modules_for_country("uk")]
+        result = validate_modules(uk_names, "uk")
+        assert result == uk_names
+
     def test_unknown_module_raises(self):
         with pytest.raises(ValueError, match="Unknown module"):
             validate_modules(["nonexistent"], "us")
@@ -132,3 +273,8 @@ class TestValidateModules:
     def test_multiple_errors_combined(self):
         with pytest.raises(ValueError, match="Unknown module.*not available"):
             validate_modules(["nonexistent", "constituency"], "us")
+
+    def test_returns_original_list_on_success(self):
+        names = ["poverty", "decile", "inequality"]
+        result = validate_modules(names, "us")
+        assert result is names


### PR DESCRIPTION
## Summary

- **Module registry**: Frozen dataclass-based registry mapping 10 module names to metadata (label, description, countries, response_fields)
- **`GET /analysis/options`**: Lists available computation modules, filterable by country
- **`POST /analysis/economy-custom`**: Runs only selected modules and returns a filtered response (nullifies unrelated fields)
- **Composable module functions**: Extracted ~680 lines of inline computation from monolithic UK/US functions into 14 standalone module functions with dispatch tables and a `run_modules()` helper
- **119 unit tests** covering registry, options endpoint, economy-custom endpoint, filtered response logic, dispatch tables, function signatures, and run_modules behavior

## Test plan

- [x] All 119 Phase 4 tests pass (`pytest tests/test_module_registry.py tests/test_analysis_options.py tests/test_economy_custom.py tests/test_computation_modules.py`)
- [x] Ruff lint/format clean on all Phase 4 files
- [ ] Verify `/analysis/options` returns correct modules per country in staging
- [ ] Verify `/analysis/economy-custom` runs only requested modules end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)