### PR TITLE
fix: Populate possible_values and set data_type='Enum' for enum variables

### DIFF
--- a/scripts/seed_models.py
+++ b/scripts/seed_models.py
@@ -28,6 +28,26 @@ from policyengine_api.models import (  # noqa: E402
 )
 
 
+def _get_variable_type_info(var) -> tuple[str, str | None]:
+    """Extract data_type and possible_values from a policyengine variable.
+
+    For enum variables (those with possible_values), returns ("Enum", json_values).
+    For other variables, returns (python_type_name, None).
+
+    Returns:
+        Tuple of (data_type, possible_values_json)
+    """
+    if var.possible_values:
+        return "Enum", json.dumps(var.possible_values)
+
+    data_type = (
+        var.data_type.__name__
+        if hasattr(var.data_type, "__name__")
+        else str(var.data_type)
+    )
+    return data_type, None
+
+
 def seed_model(
     model_version,
     session: Session,
@@ -121,16 +141,15 @@ def seed_model(
                     total=len(variables),
                 )
                 for var in variables:
+                    data_type, possible_values = _get_variable_type_info(var)
                     var_rows.append(
                         {
                             "id": uuid4(),
                             "name": var.name,
                             "entity": var.entity,
                             "description": var.description or "",
-                            "data_type": var.data_type.__name__
-                            if hasattr(var.data_type, "__name__")
-                            else str(var.data_type),
-                            "possible_values": None,
+                            "data_type": data_type,
+                            "possible_values": possible_values,
                             "tax_benefit_model_version_id": db_version.id,
                             "created_at": datetime.now(timezone.utc),
                         }

--- a/src/policyengine_api/models/variable.py
+++ b/src/policyengine_api/models/variable.py
@@ -15,7 +15,7 @@ class VariableBase(SQLModel):
     entity: str
     description: str | None = None
     data_type: str | None = None  # Store as string representation
-    possible_values: str | None = Field(
+    possible_values: list[str] | None = Field(
         default=None, sa_column=Column(JSON)
     )  # Store as JSON list
     default_value: Any = Field(


### PR DESCRIPTION
## Summary
- Populates `possible_values` field with JSON-encoded values when a variable has enumerated options
- Sets `data_type` to `"Enum"` for variables with `possible_values`, enabling frontend dropdowns
- Fixes the issue where `state_name` and other enum variables rendered as text inputs instead of dropdowns

## Context
The frontend's `VariableInput.tsx` only renders a `<Select>` dropdown when `data_type === "Enum"`. Previously, enum variables had their Python type name (e.g., `"str"`) as `data_type`, causing text inputs to render instead.

## Test plan
- [ ] Re-seed database and verify `state_name` variable has `data_type: "Enum"` and `possible_values: ["AL", "AK", ...]`
- [ ] Verify frontend renders state dropdown in household builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)