### PR TITLE
Sync ANTHROPIC_API_KEY to Modal environments

### DIFF
--- a/.github/scripts/modal-sync-secrets.sh
+++ b/.github/scripts/modal-sync-secrets.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Sync secrets from GitHub Actions to a Modal environment
 # Usage: ./modal-sync-secrets.sh <modal-environment> <logfire-environment>
-# Required env vars: SUPABASE_DB_URL, SUPABASE_URL, SUPABASE_KEY, SUPABASE_SECRET_KEY, LOGFIRE_TOKEN
+# Required env vars: SUPABASE_DB_URL, SUPABASE_URL, SUPABASE_KEY, SUPABASE_SECRET_KEY, LOGFIRE_TOKEN, ANTHROPIC_API_KEY
 set -euo pipefail
 
 MODAL_ENV="${1:?Modal environment required (staging or main)}"
@@ -21,6 +21,11 @@ uv run modal secret create policyengine-db \
 uv run modal secret create policyengine-logfire \
   "LOGFIRE_TOKEN=${LOGFIRE_TOKEN}" \
   "LOGFIRE_ENVIRONMENT=${LOGFIRE_ENV}" \
+  --env="$MODAL_ENV" \
+  --force
+
+uv run modal secret create anthropic-api-key \
+  "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
   --env="$MODAL_ENV" \
   --force
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,6 +211,7 @@ jobs:
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
           SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
           LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           chmod +x .github/scripts/*.sh
           .github/scripts/modal-sync-secrets.sh staging staging
@@ -329,6 +330,7 @@ jobs:
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
           SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
           LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           chmod +x .github/scripts/*.sh
           .github/scripts/modal-sync-secrets.sh main prod

--- a/changelog.d/sync-anthropic-key-modal.fixed
+++ b/changelog.d/sync-anthropic-key-modal.fixed
@@ -1,0 +1,1 @@
+Sync ANTHROPIC_API_KEY to Modal environments via deploy pipeline, fixing agent sandbox deploy failure.


### PR DESCRIPTION
Fixes #120

## Summary

- Add `anthropic-api-key` Modal secret creation to `modal-sync-secrets.sh`
- Pass `ANTHROPIC_API_KEY` from GitHub secrets in both staging and production sync steps in `deploy.yml`

## Test plan

- [ ] `modal deploy --env=staging src/policyengine_api/agent_sandbox.py` succeeds
- [ ] `modal secret list --env=staging` includes `anthropic-api-key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)