### PR TITLE
Harden public API write and compute routes

### DIFF
--- a/changelog.d/harden-public-api-write-and-compute-routes.fixed.md
+++ b/changelog.d/harden-public-api-write-and-compute-routes.fixed.md
@@ -1,0 +1,1 @@
+Protect public write and compute routes with an API key guard and remove anonymous database access from generated RLS policies.

--- a/scripts/init.py
+++ b/scripts/init.py
@@ -31,6 +31,105 @@ console = Console()
 PROJECT_ROOT = Path(__file__).parent.parent
 
 
+def build_rls_policies_sql() -> str:
+    """Build the SQL used to apply RLS policies.
+
+    The generated policies intentionally avoid anonymous access for database
+    tables. Storage policies remain separate because they are managed by a
+    different access pattern.
+    """
+
+    tables = [
+        "datasets",
+        "dataset_versions",
+        "simulations",
+        "reports",
+        "decile_impacts",
+        "program_statistics",
+        "policies",
+        "dynamics",
+        "aggregates",
+        "change_aggregates",
+        "tax_benefit_models",
+        "tax_benefit_model_versions",
+        "variables",
+        "parameters",
+        "parameter_values",
+        "users",
+        "household_jobs",
+        "households",
+        "user_household_associations",
+        "poverty",
+        "inequality",
+    ]
+
+    # Read-only tables are readable only by authenticated clients.
+    readonly_tables = [
+        "tax_benefit_models",
+        "tax_benefit_model_versions",
+        "variables",
+        "parameters",
+        "parameter_values",
+        "datasets",
+        "dataset_versions",
+    ]
+
+    # User-scoped and mutable tables are only accessible through the service role.
+    service_role_only_tables = [
+        "simulations",
+        "policies",
+        "dynamics",
+        "reports",
+        "household_jobs",
+        "households",
+        "aggregates",
+        "change_aggregates",
+        "decile_impacts",
+        "program_statistics",
+        "user_household_associations",
+        "poverty",
+        "inequality",
+    ]
+
+    sql_parts = []
+
+    for table in tables:
+        sql_parts.append(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;")
+
+    for table in tables:
+        sql_parts.append(
+            f"""
+        DROP POLICY IF EXISTS "Service role full access" ON {table};
+        CREATE POLICY "Service role full access" ON {table}
+        FOR ALL TO service_role USING (true) WITH CHECK (true);
+        """
+        )
+
+    for table in readonly_tables:
+        sql_parts.append(
+            f"""
+        DROP POLICY IF EXISTS "Public read access" ON {table};
+        CREATE POLICY "Public read access" ON {table}
+        FOR SELECT TO authenticated USING (true);
+        """
+        )
+
+    for table in service_role_only_tables:
+        drop_statements = [
+            f'DROP POLICY IF EXISTS "Users can create" ON {table};',
+            f'DROP POLICY IF EXISTS "Users can read" ON {table};',
+            f'DROP POLICY IF EXISTS "Public read access" ON {table};',
+        ]
+        if table == "user_household_associations":
+            drop_statements.append(
+                'DROP POLICY IF EXISTS "Users can manage own associations" '
+                "ON user_household_associations;"
+            )
+        sql_parts.append("\n".join(drop_statements))
+
+    return "\n".join(sql_parts)
+
+
 def reset_storage_bucket():
     """Delete and recreate the storage bucket."""
     console.print("[bold blue]Resetting storage bucket...")
@@ -175,119 +274,14 @@ def apply_storage_policies(engine):
 def apply_rls_policies(engine):
     """Apply row-level security policies to all tables."""
     console.print("[bold blue]Applying RLS policies...")
-
-    tables = [
-        "datasets",
-        "dataset_versions",
-        "simulations",
-        "reports",
-        "decile_impacts",
-        "program_statistics",
-        "policies",
-        "dynamics",
-        "aggregates",
-        "change_aggregates",
-        "tax_benefit_models",
-        "tax_benefit_model_versions",
-        "variables",
-        "parameters",
-        "parameter_values",
-        "users",
-        "household_jobs",
-        "households",
-        "user_household_associations",
-        "poverty",
-        "inequality",
-    ]
-
-    # Read-only tables (public can read, only service role can write)
-    readonly_tables = [
-        "tax_benefit_models",
-        "tax_benefit_model_versions",
-        "variables",
-        "parameters",
-        "parameter_values",
-        "datasets",
-        "dataset_versions",
-    ]
-
-    # User-writable tables
-    user_writable_tables = [
-        "simulations",
-        "policies",
-        "dynamics",
-        "reports",
-        "household_jobs",
-        "households",
-    ]
-
-    # Read-only results tables
-    results_tables = [
-        "aggregates",
-        "change_aggregates",
-        "decile_impacts",
-        "program_statistics",
-        "poverty",
-        "inequality",
-    ]
-
-    sql_parts = []
-
-    # Enable RLS on all tables
-    for table in tables:
-        sql_parts.append(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;")
-
-    # Service role full access on all tables
-    for table in tables:
-        sql_parts.append(f"""
-        DROP POLICY IF EXISTS "Service role full access" ON {table};
-        CREATE POLICY "Service role full access" ON {table}
-        FOR ALL TO service_role USING (true) WITH CHECK (true);
-        """)
-
-    # Public read access for read-only tables
-    for table in readonly_tables:
-        sql_parts.append(f"""
-        DROP POLICY IF EXISTS "Public read access" ON {table};
-        CREATE POLICY "Public read access" ON {table}
-        FOR SELECT TO anon, authenticated USING (true);
-        """)
-
-    # User create/read for user-writable tables
-    for table in user_writable_tables:
-        sql_parts.append(f"""
-        DROP POLICY IF EXISTS "Users can create" ON {table};
-        CREATE POLICY "Users can create" ON {table}
-        FOR INSERT TO anon, authenticated WITH CHECK (true);
-
-        DROP POLICY IF EXISTS "Users can read" ON {table};
-        CREATE POLICY "Users can read" ON {table}
-        FOR SELECT TO anon, authenticated USING (true);
-        """)
-
-    # Read access for results tables
-    for table in results_tables:
-        sql_parts.append(f"""
-        DROP POLICY IF EXISTS "Users can read" ON {table};
-        CREATE POLICY "Users can read" ON {table}
-        FOR SELECT TO anon, authenticated USING (true);
-        """)
-
-    # User-household associations need special handling
-    sql_parts.append("""
-    DROP POLICY IF EXISTS "Users can manage own associations" ON user_household_associations;
-    CREATE POLICY "Users can manage own associations" ON user_household_associations
-    FOR ALL TO anon, authenticated USING (true) WITH CHECK (true);
-    """)
-
-    sql = "\n".join(sql_parts)
+    sql = build_rls_policies_sql()
 
     conn = engine.raw_connection()
     try:
         cursor = conn.cursor()
         cursor.execute(sql)
         conn.commit()
-        console.print(f"[green]✓[/green] RLS policies applied to {len(tables)} tables")
+        console.print("[green]✓[/green] RLS policies applied to database tables")
     except Exception as e:
         console.print(f"[red]✗ Error applying RLS policies: {e}[/red]")
         raise

--- a/src/policyengine_api/api/agent.py
+++ b/src/policyengine_api/api/agent.py
@@ -11,11 +11,12 @@ import uuid
 from datetime import datetime
 
 import logfire
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import BaseModel
 
 from policyengine_api.config import settings
+from policyengine_api.security import require_expensive_endpoint_access
 
 
 def get_traceparent() -> str | None:
@@ -105,7 +106,11 @@ def _run_local_agent(
         _calls[call_id]["result"] = {"status": "failed", "error": str(e)}
 
 
-@router.post("/run", response_model=RunResponse)
+@router.post(
+    "/run",
+    response_model=RunResponse,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 async def run_agent(request: RunRequest) -> RunResponse:
     """Start the agent to answer a policy question.
 
@@ -186,7 +191,10 @@ async def run_agent(request: RunRequest) -> RunResponse:
     return RunResponse(call_id=call_id, status="running")
 
 
-@router.post("/log/{call_id}")
+@router.post(
+    "/log/{call_id}",
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 async def post_log(call_id: str, log_input: LogInput) -> dict:
     """Receive a log entry from the running agent.
 
@@ -204,7 +212,10 @@ async def post_log(call_id: str, log_input: LogInput) -> dict:
     return {"status": "ok"}
 
 
-@router.post("/complete/{call_id}")
+@router.post(
+    "/complete/{call_id}",
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 async def complete_call(call_id: str, result: dict) -> dict:
     """Mark a call as complete with its result.
 

--- a/src/policyengine_api/api/analysis.py
+++ b/src/policyengine_api/api/analysis.py
@@ -67,6 +67,7 @@ from policyengine_api.models import (
 from policyengine_api.runtime_versions import (
     resolve_shared_runtime_model_version_from_db,
 )
+from policyengine_api.security import require_expensive_endpoint_access
 from policyengine_api.services.database import get_session
 from policyengine_api.services.model_resolver import (
     resolve_country_from_simulation,
@@ -1232,7 +1233,11 @@ def _resolve_dataset_and_region(
         )
 
 
-@router.post("/economic-impact", response_model=EconomicImpactResponse)
+@router.post(
+    "/economic-impact",
+    response_model=EconomicImpactResponse,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def economic_impact(
     request: EconomicImpactRequest,
     session: Session = Depends(get_session),
@@ -1318,7 +1323,11 @@ def economic_impact(
     return _build_response(report, baseline_sim, reform_sim, session, region)
 
 
-@router.get("/economic-impact/{report_id}", response_model=EconomicImpactResponse)
+@router.get(
+    "/economic-impact/{report_id}",
+    response_model=EconomicImpactResponse,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def get_economic_impact_status(
     report_id: UUID,
     session: Session = Depends(get_session),
@@ -1436,7 +1445,11 @@ def _build_filtered_response(
     return EconomicImpactResponse.model_construct(**filtered)
 
 
-@router.post("/economy-custom", response_model=EconomicImpactResponse)
+@router.post(
+    "/economy-custom",
+    response_model=EconomicImpactResponse,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def economy_custom(
     request: EconomyCustomRequest,
     session: Session = Depends(get_session),
@@ -1543,7 +1556,11 @@ def economy_custom(
     return _build_filtered_response(full_response, request.modules)
 
 
-@router.get("/economy-custom/{report_id}", response_model=EconomicImpactResponse)
+@router.get(
+    "/economy-custom/{report_id}",
+    response_model=EconomicImpactResponse,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def get_economy_custom_status(
     report_id: UUID,
     modules: str | None = None,
@@ -1593,7 +1610,11 @@ class RerunResponse(BaseModel):
     status: str
 
 
-@router.post("/rerun/{report_id}", response_model=RerunResponse)
+@router.post(
+    "/rerun/{report_id}",
+    response_model=RerunResponse,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def rerun_report(
     report_id: UUID,
     session: Session = Depends(get_session),

--- a/src/policyengine_api/api/change_aggregates.py
+++ b/src/policyengine_api/api/change_aggregates.py
@@ -20,6 +20,7 @@ from policyengine_api.models import (
     TaxBenefitModel,
     TaxBenefitModelVersion,
 )
+from policyengine_api.security import require_expensive_endpoint_access
 from policyengine_api.services.database import get_session
 
 router = APIRouter(prefix="/outputs/change-aggregates", tags=["change-aggregates"])
@@ -84,7 +85,11 @@ def _trigger_change_aggregate_computation(
     )
 
 
-@router.post("", response_model=List[ChangeAggregateRead])
+@router.post(
+    "",
+    response_model=List[ChangeAggregateRead],
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def create_change_aggregates(
     outputs: List[ChangeAggregateCreate],
     background_tasks: BackgroundTasks,
@@ -129,14 +134,22 @@ def create_change_aggregates(
     return db_outputs
 
 
-@router.get("", response_model=List[ChangeAggregateRead])
+@router.get(
+    "",
+    response_model=List[ChangeAggregateRead],
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def list_change_aggregates(session: Session = Depends(get_session)):
     """List all change aggregates."""
     outputs = session.exec(select(ChangeAggregate)).all()
     return outputs
 
 
-@router.get("/{output_id}", response_model=ChangeAggregateRead)
+@router.get(
+    "/{output_id}",
+    response_model=ChangeAggregateRead,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def get_change_aggregate(output_id: UUID, session: Session = Depends(get_session)):
     """Get a specific change aggregate."""
     output = session.get(ChangeAggregate, output_id)

--- a/src/policyengine_api/api/dynamics.py
+++ b/src/policyengine_api/api/dynamics.py
@@ -11,12 +11,17 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
 from policyengine_api.models import Dynamic, DynamicCreate, DynamicRead
+from policyengine_api.security import require_expensive_endpoint_access
 from policyengine_api.services.database import get_session
 
 router = APIRouter(prefix="/dynamics", tags=["dynamics"])
 
 
-@router.post("/", response_model=DynamicRead)
+@router.post(
+    "/",
+    response_model=DynamicRead,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def create_dynamic(dynamic: DynamicCreate, session: Session = Depends(get_session)):
     """Create a new behavioural dynamics specification.
 

--- a/src/policyengine_api/api/household.py
+++ b/src/policyengine_api/api/household.py
@@ -21,6 +21,7 @@ from policyengine_api.models import (
     HouseholdJobStatus,
     Policy,
 )
+from policyengine_api.security import require_expensive_endpoint_access
 from policyengine_api.services.database import get_session
 
 
@@ -841,7 +842,11 @@ def _get_dynamic_data(dynamic_id: UUID | None, session: Session) -> dict | None:
     }
 
 
-@router.post("/calculate", response_model=HouseholdJobResponse)
+@router.post(
+    "/calculate",
+    response_model=HouseholdJobResponse,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def calculate_household(
     request: HouseholdCalculateRequest,
     session: Session = Depends(get_session),
@@ -973,7 +978,11 @@ def _compute_impact(
     return impact
 
 
-@router.post("/impact", response_model=HouseholdJobResponse)
+@router.post(
+    "/impact",
+    response_model=HouseholdJobResponse,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def calculate_household_impact_comparison(
     request: HouseholdImpactRequest,
     session: Session = Depends(get_session),

--- a/src/policyengine_api/api/household_analysis.py
+++ b/src/policyengine_api/api/household_analysis.py
@@ -31,6 +31,7 @@ from policyengine_api.models import (
     SimulationStatus,
     SimulationType,
 )
+from policyengine_api.security import require_expensive_endpoint_access
 from policyengine_api.services.database import get_session
 from policyengine_api.services.model_resolver import (
     resolve_country_from_simulation,
@@ -665,6 +666,7 @@ def validate_policy_exists(policy_id: UUID | None, session: Session) -> None:
 @router.post("/household-impact", response_model=HouseholdImpactResponse)
 def household_impact(
     request: HouseholdImpactRequest,
+    _: None = Depends(require_expensive_endpoint_access),
     session: Session = Depends(get_session),
 ) -> HouseholdImpactResponse:
     """Run household impact analysis.
@@ -729,6 +731,7 @@ def household_impact(
 @router.get("/household-impact/{report_id}", response_model=HouseholdImpactResponse)
 def get_household_impact(
     report_id: UUID,
+    _: None = Depends(require_expensive_endpoint_access),
     session: Session = Depends(get_session),
 ) -> HouseholdImpactResponse:
     """Get household impact analysis status and results."""

--- a/src/policyengine_api/api/outputs.py
+++ b/src/policyengine_api/api/outputs.py
@@ -19,6 +19,7 @@ from policyengine_api.models import (
     TaxBenefitModel,
     TaxBenefitModelVersion,
 )
+from policyengine_api.security import require_expensive_endpoint_access
 from policyengine_api.services.database import get_session
 
 router = APIRouter(prefix="/outputs/aggregates", tags=["aggregates"])
@@ -83,7 +84,11 @@ def _trigger_aggregate_computation(
     )
 
 
-@router.post("", response_model=List[AggregateOutputRead])
+@router.post(
+    "",
+    response_model=List[AggregateOutputRead],
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def create_aggregate_outputs(
     outputs: List[AggregateOutputCreate],
     background_tasks: BackgroundTasks,
@@ -122,14 +127,22 @@ def create_aggregate_outputs(
     return db_outputs
 
 
-@router.get("", response_model=List[AggregateOutputRead])
+@router.get(
+    "",
+    response_model=List[AggregateOutputRead],
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def list_aggregate_outputs(session: Session = Depends(get_session)):
     """List all aggregates."""
     outputs = session.exec(select(AggregateOutput)).all()
     return outputs
 
 
-@router.get("/{output_id}", response_model=AggregateOutputRead)
+@router.get(
+    "/{output_id}",
+    response_model=AggregateOutputRead,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def get_aggregate_output(output_id: UUID, session: Session = Depends(get_session)):
     """Get a specific aggregate."""
     output = session.get(AggregateOutput, output_id)

--- a/src/policyengine_api/api/policies.py
+++ b/src/policyengine_api/api/policies.py
@@ -43,6 +43,7 @@ from policyengine_api.models import (
     PolicyRead,
     TaxBenefitModel,
 )
+from policyengine_api.security import require_expensive_endpoint_access
 from policyengine_api.services.database import get_session
 
 
@@ -77,7 +78,11 @@ def _policy_to_read(policy: Policy) -> PolicyRead:
 router = APIRouter(prefix="/policies", tags=["policies"])
 
 
-@router.post("/", response_model=PolicyRead)
+@router.post(
+    "/",
+    response_model=PolicyRead,
+    dependencies=[Depends(require_expensive_endpoint_access)],
+)
 def create_policy(policy: PolicyCreate, session: Session = Depends(get_session)):
     """Create a new policy reform with parameter values.
 

--- a/src/policyengine_api/config/settings.py
+++ b/src/policyengine_api/config/settings.py
@@ -37,6 +37,8 @@ class Settings(BaseSettings):
     api_version: str = _get_version()
     api_port: int = 8000
     debug: bool = False
+    cors_allowed_origins: str = "http://localhost:3000,http://127.0.0.1:3000"
+    expensive_endpoint_api_key: str = ""
 
     # Seeding
     limit_seed_parameters: bool = False
@@ -71,6 +73,15 @@ class Settings(BaseSettings):
             ).replace("https://", "postgresql://postgres:postgres@")
             + "/postgres"
         )
+
+    @property
+    def cors_origins(self) -> list[str]:
+        """Return the configured CORS allowlist."""
+        return [
+            origin.strip()
+            for origin in self.cors_allowed_origins.split(",")
+            if origin.strip()
+        ]
 
 
 settings = Settings()

--- a/src/policyengine_api/main.py
+++ b/src/policyengine_api/main.py
@@ -65,7 +65,7 @@ app = FastAPI(
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/policyengine_api/security.py
+++ b/src/policyengine_api/security.py
@@ -1,0 +1,25 @@
+"""Security helpers for public API guardrails."""
+
+from typing import Annotated
+
+from fastapi import Header, HTTPException, Request, status
+
+from policyengine_api.config.settings import settings
+
+
+def require_expensive_endpoint_access(
+    request: Request,
+    x_policyengine_api_key: Annotated[
+        str | None, Header(alias="X-PolicyEngine-Api-Key")
+    ] = None,
+) -> None:
+    """Require a shared key for callers of expensive endpoints."""
+
+    expected_key = settings.expensive_endpoint_api_key.strip()
+    if expected_key and x_policyengine_api_key == expected_key:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="X-PolicyEngine-Api-Key header required",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,17 @@ from policyengine_api.models import (
     TaxBenefitModel,
     TaxBenefitModelVersion,
 )
+from policyengine_api.security import require_expensive_endpoint_access
 from policyengine_api.services.database import get_session
+
+
+@pytest.fixture(autouse=True)
+def expensive_endpoint_auth_override():
+    """Keep behavioral tests focused on endpoint logic, not API-key wiring."""
+
+    app.dependency_overrides[require_expensive_endpoint_access] = lambda: None
+    yield
+    app.dependency_overrides.pop(require_expensive_endpoint_access, None)
 
 
 @pytest.fixture(name="session")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,163 @@
+"""Security regression tests for remote attack surface hardening."""
+
+from fastapi import HTTPException, Request
+
+from policyengine_api.config.settings import settings
+from policyengine_api.main import app
+from policyengine_api.security import require_expensive_endpoint_access
+from scripts.init import build_rls_policies_sql
+
+
+def _make_request(
+    path: str, client_host: str = "203.0.113.10", headers: dict | None = None
+) -> Request:
+    raw_headers = [(b"host", b"api.policyengine.org")]
+    for key, value in (headers or {}).items():
+        raw_headers.append((key.lower().encode("ascii"), value.encode("ascii")))
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "https",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": (client_host, 443),
+        "server": ("api.policyengine.org", 443),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def test_expensive_endpoint_guard_blocks_external_requests_without_key():
+    request = _make_request("/analysis/economic-impact")
+
+    try:
+        require_expensive_endpoint_access(request)
+    except HTTPException as exc:
+        assert exc.status_code == 401
+    else:
+        raise AssertionError("expected external requests without a key to be rejected")
+
+
+def test_expensive_endpoint_guard_blocks_testclient_without_key():
+    request = _make_request("/analysis/economic-impact", client_host="testclient")
+
+    try:
+        require_expensive_endpoint_access(request)
+    except HTTPException as exc:
+        assert exc.status_code == 401
+    else:
+        raise AssertionError(
+            "expected testclient requests without a key to be rejected"
+        )
+
+
+def test_expensive_endpoint_guard_allows_external_requests_with_key(monkeypatch):
+    monkeypatch.setattr(settings, "expensive_endpoint_api_key", "secret-key")
+    request = _make_request(
+        "/analysis/economic-impact",
+        headers={"X-PolicyEngine-Api-Key": "secret-key"},
+    )
+
+    assert (
+        require_expensive_endpoint_access(request, x_policyengine_api_key="secret-key")
+        is None
+    )
+
+
+def test_expensive_routes_are_protected():
+    protected_routes = {
+        ("POST", "/analysis/economic-impact"),
+        ("GET", "/analysis/economic-impact/{report_id}"),
+        ("POST", "/analysis/economy-custom"),
+        ("GET", "/analysis/economy-custom/{report_id}"),
+        ("POST", "/analysis/rerun/{report_id}"),
+        ("POST", "/policies/"),
+        ("POST", "/dynamics/"),
+        ("POST", "/household/calculate"),
+        ("POST", "/household/impact"),
+        ("POST", "/analysis/household-impact"),
+        ("GET", "/analysis/household-impact/{report_id}"),
+        ("POST", "/outputs/aggregates"),
+        ("GET", "/outputs/aggregates"),
+        ("GET", "/outputs/aggregates/{output_id}"),
+        ("POST", "/outputs/change-aggregates"),
+        ("GET", "/outputs/change-aggregates"),
+        ("GET", "/outputs/change-aggregates/{output_id}"),
+        ("POST", "/agent/run"),
+        ("POST", "/agent/log/{call_id}"),
+        ("POST", "/agent/complete/{call_id}"),
+    }
+
+    route_map = {}
+    for route in app.routes:
+        methods = getattr(route, "methods", None)
+        if not methods:
+            continue
+        for method in methods:
+            if method in {"GET", "POST"}:
+                route_map[(method, route.path)] = route
+
+    for route_key in protected_routes:
+        route = route_map[route_key]
+        assert any(
+            getattr(dependency.call, "__name__", "")
+            == "require_expensive_endpoint_access"
+            for dependency in route.dependant.dependencies
+        ), route_key
+
+
+def test_cors_allows_configured_local_origin(client):
+    response = client.get(
+        "/health",
+        headers={"Origin": "http://localhost:3000"},
+    )
+
+    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+
+
+def test_cors_rejects_unconfigured_origin(client):
+    response = client.get(
+        "/health",
+        headers={"Origin": "https://evil.example"},
+    )
+
+    assert response.headers.get("access-control-allow-origin") is None
+
+
+def test_init_rls_sql_does_not_grant_anonymous_database_access():
+    sql = build_rls_policies_sql()
+    service_role_only_tables = {
+        "simulations",
+        "policies",
+        "dynamics",
+        "reports",
+        "household_jobs",
+        "households",
+        "aggregates",
+        "change_aggregates",
+        "decile_impacts",
+        "program_statistics",
+        "user_household_associations",
+        "poverty",
+        "inequality",
+    }
+
+    assert "TO anon" not in sql
+    assert 'CREATE POLICY "Public read access" ON datasets' in sql
+    assert "FOR SELECT TO authenticated" in sql
+    for table in service_role_only_tables:
+        assert f'CREATE POLICY "Users can create" ON {table}' not in sql
+        assert f'CREATE POLICY "Users can read" ON {table}' not in sql
+        assert f'CREATE POLICY "Public read access" ON {table}' not in sql
+    assert (
+        'DROP POLICY IF EXISTS "Users can manage own associations" '
+        "ON user_household_associations;"
+    ) in sql


### PR DESCRIPTION
## Summary
- require the shared expensive-endpoint guard on public policy, dynamic, aggregate, household, and agent write routes
- protect additional expensive analysis POST routes and restrict CORS to a configured allowlist
- remove anonymous database access from generated RLS policies and add security regression coverage

## Testing
- uv run pytest tests/test_outputs.py tests/test_change_aggregates.py tests/test_security.py -q
- uv run ruff check src/policyengine_api/security.py src/policyengine_api/config/settings.py src/policyengine_api/main.py src/policyengine_api/api/analysis.py src/policyengine_api/api/outputs.py src/policyengine_api/api/change_aggregates.py src/policyengine_api/api/agent.py src/policyengine_api/api/policies.py src/policyengine_api/api/dynamics.py scripts/init.py tests/test_security.py