### PR TITLE
Skip Terraform apply when infrastructure is unchanged

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,23 +152,50 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check Terraform changes
+        id: terraform-changes
+        run: |
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BEFORE_SHA="${{ github.event.before }}"
+          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet "$BEFORE_SHA" "${{ github.sha }}" -- terraform; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Terraform changes detected; skipping Terraform apply."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Authenticate to Google Cloud
+        if: steps.terraform-changes.outputs.changed == 'true'
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Setup Terraform
+        if: steps.terraform-changes.outputs.changed == 'true'
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.15.3
 
       - name: Terraform init
+        if: steps.terraform-changes.outputs.changed == 'true'
         working-directory: ./terraform
         run: terraform init -input=false
 
       - name: Terraform plan
+        if: steps.terraform-changes.outputs.changed == 'true'
         working-directory: ./terraform
         env:
           TF_VAR_supabase_url: ${{ secrets.SUPABASE_URL }}
@@ -183,6 +210,7 @@ jobs:
         run: terraform plan -out=tfplan -input=false
 
       - name: Terraform apply
+        if: steps.terraform-changes.outputs.changed == 'true'
         working-directory: ./terraform
         run: terraform apply -input=false tfplan
 

--- a/changelog.d/363.fixed.md
+++ b/changelog.d/363.fixed.md
@@ -1,0 +1,1 @@
+Skip Terraform apply during runtime-only deploys so unchanged infrastructure does not block API releases.


### PR DESCRIPTION
## Summary
- make the deploy workflow no-op the Terraform apply job when a push did not change terraform/**
- keep downstream deploy jobs unblocked because the infra job still succeeds
- update the Terraform CLI used for real infra changes

## Why
The production deploy from #362 failed before application deploy in Terraform provider installation, even though this runtime release did not change infrastructure: https://github.com/PolicyEngine/policyengine-api-v2-alpha/actions/runs/25801578616

## Testing
- /tmp/actionlint-pe-api -color .github/workflows/deploy.yml