### PR TITLE
Update production Supabase env vars during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -503,7 +503,7 @@ jobs:
             --image="${IMAGE_URL}:${{ github.sha }}" \
             --tag=canary \
             --no-traffic \
-            --update-env-vars=MODAL_ENVIRONMENT=main,LOGFIRE_ENVIRONMENT=prod
+            --update-env-vars=MODAL_ENVIRONMENT=main,LOGFIRE_ENVIRONMENT=prod,SUPABASE_URL=${{ secrets.SUPABASE_URL }},SUPABASE_KEY=${{ secrets.SUPABASE_KEY }},SUPABASE_SECRET_KEY=${{ secrets.SUPABASE_SECRET_KEY }},SUPABASE_DB_URL=${{ secrets.SUPABASE_DB_URL }}
 
       - name: Smoke test canary
         run: |

--- a/changelog.d/365.fixed.md
+++ b/changelog.d/365.fixed.md
@@ -1,0 +1,1 @@
+Update production Cloud Run Supabase environment variables during deploys.


### PR DESCRIPTION
## Summary
- pass Supabase URL/key/DB env vars in the production Cloud Run deploy step, matching staging
- keeps the live API pointed at the same production database that db-reseed uses

## Why
The production full reseed succeeded after #364, but the live Cloud Run endpoint still read the old model rows because production deploys were not refreshing Supabase env vars. The staging deploy already set these values; production only set Modal/Logfire.

## Testing
- /tmp/actionlint-pe-api -color .github/workflows/deploy.yml